### PR TITLE
feat: add hybrid agent

### DIFF
--- a/agents/hybrid.py
+++ b/agents/hybrid.py
@@ -1,0 +1,109 @@
+import numpy as np
+from utils import softmax
+
+"""
+Hybrid agent similar to the one used in Daw et al. (2011)
+Differences:
+- Eligibility traces are not used
+- Softmax perseveration parameter p is not used
+- Therefore has 5 free parameters instead of 7
+"""
+
+
+class HybridAgent:
+    def __init__(self, action_space, state_space, alpha_1=0.1, alpha_2=0.1, beta_1=0.9, beta_2=0.9, w=0):
+        """
+        Initialize hybrid agent
+        :param action_space: Action space of the environment
+        :param state_space: State space of the environment
+        :param alpha_1: Learning rate for first step
+        :param alpha_2: Learning rate for second step
+        :param beta_1: Temperature parameter for softmax policy for first step
+        :param beta_2: Temperature parameter for softmax policy for second step
+        :param w: Weight of model-based values (0 for model-free, 1 for model-based)
+        """
+        self.action_space = action_space
+        self.state_space = state_space
+        self.alpha_1 = alpha_1
+        self.alpha_2 = alpha_2
+        self.beta_1 = beta_1
+        self.beta_2 = beta_2
+        self.w = w
+
+        self.q_td = np.zeros((len(state_space), len(action_space)))  # Q-table for model-free agent
+        self.q_mb = np.zeros((len(state_space), len(action_space)))  # Q-table for model-based agent
+        self.q_net = np.zeros((len(state_space), len(action_space)))  # Q-table for model-based agent
+        self.q_table = self.q_net
+
+        # Initialize transition model as a 3D numpy array
+        # Dimensions: [current_state, action, next_state]
+        # For simplicity, initializing all transitions as equally likely
+        self.transition_model = np.zeros((len(state_space), len(action_space), len(state_space)))
+        self.transition_counts = np.zeros((len(state_space), len(action_space), len(state_space)))
+
+    def calculate_rpe(self, state, action, reward, next_state, next_action, terminal):
+        """
+        Calculate the reward prediction error
+        :param state: current state
+        :param action: current action
+        :param reward: reward received in the current state
+        :param next_state: next state
+        :param next_action: next action
+        :param terminal: whether this state is terminal
+        :return:
+        """
+        if terminal:
+            return reward - self.q_td[state, action]
+        else:
+            return reward + self.q_td[next_state, next_action] - self.q_td[state, action]
+
+    def update_q_td(self, state, action, rpe):
+        """
+        Update the Q-table for model-free agent
+        :param state: Current state
+        :param action: Current action
+        :param rpe: Reward prediction error
+        :return:
+        """
+        alpha = self.alpha_1 if state == 0 else self.alpha_2
+        self.q_td[state, action] += alpha * rpe
+
+    def update_transition_model(self, current_state, action, next_state, terminal):
+        if terminal:
+            return
+
+        # Increment the count for the observed transition
+        self.transition_counts[current_state, action, next_state] += 1
+
+        # Check if the transition is common or rare
+        is_common_transition = self.transition_counts[current_state, action, next_state] == np.max(
+            self.transition_counts[current_state, action])
+        # Update the transition probabilities
+        self.transition_model[current_state, action, next_state] = 0.7 if is_common_transition else 0.3
+        other_states = np.array([state for state in self.state_space[1:] if state != next_state])
+        for other_state in other_states:
+            self.transition_model[current_state, action, other_state] = 0.3 if is_common_transition else 0.7
+
+    def update_q_mb(self, state, action):
+        if state == 0:
+            self.q_mb[state, action] = np.sum(
+                [self.transition_model[state, action, i] * np.max(self.q_td[i, :]) for i in self.state_space[1:]])
+        else:
+            self.q_mb[state, action] = self.q_td[state, action]
+
+    def update_q_net(self, state, action):
+        self.q_net[state, action] = self.w * self.q_mb[state, action] + (1 - self.w) * self.q_td[state, action]
+
+    def update_beliefs(self, current_state, action, reward, next_state, terminal):
+        next_action = self.policy(next_state)
+        rpe = self.calculate_rpe(current_state, action, reward, next_state, next_action, terminal)
+        self.update_q_td(current_state, action, rpe)
+        self.update_transition_model(current_state, action, next_state, terminal)
+        self.update_q_mb(current_state, action)
+        self.update_q_net(current_state, action)
+
+    def policy(self, state, method=None):
+        beta = self.beta_1 if state == 0 else self.beta_2
+        # TODO - Implement the softmax policy in the paper with parameter "p"
+        action_probabilities = softmax(self.q_net[state, :], beta)
+        return np.random.choice(self.action_space, p=action_probabilities)

--- a/agents/hybrid.py
+++ b/agents/hybrid.py
@@ -107,3 +107,7 @@ class HybridAgent:
         # TODO - Implement the softmax policy in the paper with parameter "p"
         action_probabilities = softmax(self.q_net[state, :], beta)
         return np.random.choice(self.action_space, p=action_probabilities)
+
+    def get_action_probabilities(self, state):
+        beta = self.beta_1 if state == 0 else self.beta_2
+        return softmax(self.q_net[state, :], beta)

--- a/simulate.py
+++ b/simulate.py
@@ -1,9 +1,9 @@
 import pandas as pd
 import numpy as np
-import os
 
 from agents.model_based import AgentModelBased
 from agents.model_free import AgentModelFree
+from agents.hybrid import HybridAgent
 from agents.random_agent import RandomAgent
 from environment import TwoStepEnv
 from utils import random_walk_gaussian
@@ -24,6 +24,8 @@ def simulate(agent_type='random', trials=200, seed=0, verbose=False, params:dict
         agent = AgentModelBased(action_space, state_space, **params)
     elif agent_type == 'model_free':
         agent = AgentModelFree(action_space, state_space, **params)
+    elif agent_type == 'hybrid':
+        agent = HybridAgent(action_space, state_space, **params)
     else:
         agent = RandomAgent(action_space, state_space, **params)
     env = TwoStepEnv()

--- a/utils.py
+++ b/utils.py
@@ -266,6 +266,22 @@ def print_simple_statistics(data: pd.DataFrame, full=False, title=""):
         display(reward_probabilities)
 
 
+def softmax(arr, beta):
+    e_x = np.exp(beta * (arr - np.max(arr)))  # subtract max value to prevent overflow
+    return e_x / e_x.sum(axis=0)  # axis=0 for column-wise operation if arr is 2D, otherwise it's not needed
+
+
+def calculate_bic(num_params, num_data_points, mle):
+    """
+    Calculates Bayesian Information Criterion to be used in model comparison
+    :param num_params: Number of free parameters that the model has
+    :param num_data_points: Number of data points the model has been fitted to
+    :param mle: Maximum likelihood estimation for the model given data
+    :return:
+    """
+    return num_params * np.log(num_data_points) - 2 * np.log(mle)
+
+
 if __name__ == "__main__":
     # Load latest simulated data from csv
     agent_type = "model_based"

--- a/utils.py
+++ b/utils.py
@@ -266,60 +266,6 @@ def print_simple_statistics(data: pd.DataFrame, full=False, title=""):
         display(reward_probabilities)
 
 
-def calculate_running_step_probabilities(data):
-    task_df = data.copy()
-    # Initialize columns for stay decisions and running probabilities
-    task_df['stay_decision'] = False
-    task_df['common_rewarded_prob'] = 0.0
-    task_df['common_unrewarded_prob'] = 0.0
-    task_df['rare_rewarded_prob'] = 0.0
-    task_df['rare_unrewarded_prob'] = 0.0
-    
-    # Trackers for calculating running probabilities
-    stay_counts = {'common_rewarded': 0, 'common_unrewarded': 0, 'rare_rewarded': 0, 'rare_unrewarded': 0}
-    total_counts = {'common_rewarded': 0, 'common_unrewarded': 0, 'rare_rewarded': 0, 'rare_unrewarded': 0}
-    
-    for i in range(1, len(task_df)):
-        current = task_df.iloc[i]
-        prev = task_df.iloc[i-1]
-        
-        # Check if the participant stayed with the same choice
-        if current['stepOneChoice'] == prev['stepOneChoice']:
-            task_df.loc[i, 'stay_decision'] = True
-            
-        condition = ('common_' if current['common_transition'] else 'rare_') + ('rewarded' if current['reward'] else 'unrewarded')
-        
-        # Update counts
-        if task_df.loc[i, 'stay_decision']:
-            stay_counts[condition] += 1
-        total_counts[condition] += 1
-        
-        # Calculate running probabilities
-        for key in stay_counts:
-            if total_counts[key] > 0:
-                task_df.loc[i, key + '_prob'] = stay_counts[key] / total_counts[key]
-                
-    return task_df
-
-
-def plot_running_step_probabilities(task_df):
-    plt.figure(figsize=(12, 8))
-
-    # Plot each condition's running probability
-    plt.plot(task_df['trial_index'], task_df['common_rewarded_prob'], label='Common Rewarded')
-    plt.plot(task_df['trial_index'], task_df['common_unrewarded_prob'], label='Common Unrewarded')
-    plt.plot(task_df['trial_index'], task_df['rare_rewarded_prob'], label='Rare Rewarded')
-    plt.plot(task_df['trial_index'], task_df['rare_unrewarded_prob'], label='Rare Unrewarded')
-
-    plt.title('Running Step Probabilities Over Trials')
-    plt.xlabel('Trial Index')
-    plt.ylabel('Running Stay Probability')
-    plt.legend()
-    plt.grid()
-
-    plt.show()
-
-
 if __name__ == "__main__":
     # Load latest simulated data from csv
     agent_type = "model_based"


### PR DESCRIPTION
hybrid agent similar to the one in Daw et al. (2011) that uses a free parameter "w" to weigh model-free and model-based choices. differences from the paper:
- perseveration parameter "p" in the softmax function is not used. softmax needs to be rewritten for the hybrid agent
- td_lambda parameter and eligibility traces are not used